### PR TITLE
Break out of loop if msgCh is closed

### DIFF
--- a/examples/conn_example.go
+++ b/examples/conn_example.go
@@ -43,7 +43,12 @@ L1:
 		log.Printf("amqp: consumption started")
 		for {
 			select {
-			case msg := <-msgCh:
+			case msg, ok := <-msgCh:
+				if !ok {
+					log.Printf("amqp: consumption stopped")
+
+					continue L1
+				}
 				// process message here
 				log.Printf(string(msg.Body))
 				msg.Ack(false)


### PR DESCRIPTION
The code that is reading from `msgCh` is optimistic about the `msgCh` channel being open all the time. If we introduce a fault like deleting a queue from the broker while the consumer is listening, the consumer here goes into a non-stop loop of trying to consume from a closed channel.

By checking the `msgCh` to see if it is closed, we can respond appropriately and redeclare the amqp topology (queues, etc) if the msgCh is closed, and avoid sending the code into the non-stop loop.

See also #5 