### PR TITLE
[dialer] Remove connection NotifyClose method.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -37,11 +37,11 @@ func proxyConsumerConn(
 					return
 				}
 
-				consumerConn := consumer.NewConnection(conn.AMQPConnection(), conn.NotifyClose())
+				consumerConn := consumer.NewConnection(conn.AMQPConnection(), conn.NotifyLost())
 
 				select {
 				case consumerConnCh <- consumerConn:
-				case <-conn.NotifyClose():
+				case <-conn.NotifyLost():
 					continue
 				case <-consumerCloseCh:
 					return

--- a/consumer/mock_consumer/mocks.go
+++ b/consumer/mock_consumer/mocks.go
@@ -5,58 +5,59 @@
 package mock_consumer
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	amqp "github.com/streadway/amqp"
-	reflect "reflect"
 )
 
-// MockAMQPConnection is a mock of AMQPConnection interface
+// MockAMQPConnection is a mock of AMQPConnection interface.
 type MockAMQPConnection struct {
 	ctrl     *gomock.Controller
 	recorder *MockAMQPConnectionMockRecorder
 }
 
-// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection
+// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection.
 type MockAMQPConnectionMockRecorder struct {
 	mock *MockAMQPConnection
 }
 
-// NewMockAMQPConnection creates a new mock instance
+// NewMockAMQPConnection creates a new mock instance.
 func NewMockAMQPConnection(ctrl *gomock.Controller) *MockAMQPConnection {
 	mock := &MockAMQPConnection{ctrl: ctrl}
 	mock.recorder = &MockAMQPConnectionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAMQPConnection) EXPECT() *MockAMQPConnectionMockRecorder {
 	return m.recorder
 }
 
-// MockAMQPChannel is a mock of AMQPChannel interface
+// MockAMQPChannel is a mock of AMQPChannel interface.
 type MockAMQPChannel struct {
 	ctrl     *gomock.Controller
 	recorder *MockAMQPChannelMockRecorder
 }
 
-// MockAMQPChannelMockRecorder is the mock recorder for MockAMQPChannel
+// MockAMQPChannelMockRecorder is the mock recorder for MockAMQPChannel.
 type MockAMQPChannelMockRecorder struct {
 	mock *MockAMQPChannel
 }
 
-// NewMockAMQPChannel creates a new mock instance
+// NewMockAMQPChannel creates a new mock instance.
 func NewMockAMQPChannel(ctrl *gomock.Controller) *MockAMQPChannel {
 	mock := &MockAMQPChannel{ctrl: ctrl}
 	mock.recorder = &MockAMQPChannelMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAMQPChannel) EXPECT() *MockAMQPChannelMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockAMQPChannel) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -64,13 +65,13 @@ func (m *MockAMQPChannel) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockAMQPChannelMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPChannel)(nil).Close))
 }
 
-// Consume mocks base method
+// Consume mocks base method.
 func (m *MockAMQPChannel) Consume(arg0, arg1 string, arg2, arg3, arg4, arg5 bool, arg6 amqp.Table) (<-chan amqp.Delivery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Consume", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -79,13 +80,13 @@ func (m *MockAMQPChannel) Consume(arg0, arg1 string, arg2, arg3, arg4, arg5 bool
 	return ret0, ret1
 }
 
-// Consume indicates an expected call of Consume
+// Consume indicates an expected call of Consume.
 func (mr *MockAMQPChannelMockRecorder) Consume(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Consume", reflect.TypeOf((*MockAMQPChannel)(nil).Consume), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-// NotifyCancel mocks base method
+// NotifyCancel mocks base method.
 func (m *MockAMQPChannel) NotifyCancel(arg0 chan string) chan string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyCancel", arg0)
@@ -93,13 +94,13 @@ func (m *MockAMQPChannel) NotifyCancel(arg0 chan string) chan string {
 	return ret0
 }
 
-// NotifyCancel indicates an expected call of NotifyCancel
+// NotifyCancel indicates an expected call of NotifyCancel.
 func (mr *MockAMQPChannelMockRecorder) NotifyCancel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyCancel", reflect.TypeOf((*MockAMQPChannel)(nil).NotifyCancel), arg0)
 }
 
-// NotifyClose mocks base method
+// NotifyClose mocks base method.
 func (m *MockAMQPChannel) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyClose", arg0)
@@ -107,13 +108,13 @@ func (m *MockAMQPChannel) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error {
 	return ret0
 }
 
-// NotifyClose indicates an expected call of NotifyClose
+// NotifyClose indicates an expected call of NotifyClose.
 func (mr *MockAMQPChannelMockRecorder) NotifyClose(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyClose", reflect.TypeOf((*MockAMQPChannel)(nil).NotifyClose), arg0)
 }
 
-// Qos mocks base method
+// Qos mocks base method.
 func (m *MockAMQPChannel) Qos(arg0, arg1 int, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Qos", arg0, arg1, arg2)
@@ -121,13 +122,13 @@ func (m *MockAMQPChannel) Qos(arg0, arg1 int, arg2 bool) error {
 	return ret0
 }
 
-// Qos indicates an expected call of Qos
+// Qos indicates an expected call of Qos.
 func (mr *MockAMQPChannelMockRecorder) Qos(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Qos", reflect.TypeOf((*MockAMQPChannel)(nil).Qos), arg0, arg1, arg2)
 }
 
-// QueueBind mocks base method
+// QueueBind mocks base method.
 func (m *MockAMQPChannel) QueueBind(arg0, arg1, arg2 string, arg3 bool, arg4 amqp.Table) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueueBind", arg0, arg1, arg2, arg3, arg4)
@@ -135,13 +136,13 @@ func (m *MockAMQPChannel) QueueBind(arg0, arg1, arg2 string, arg3 bool, arg4 amq
 	return ret0
 }
 
-// QueueBind indicates an expected call of QueueBind
+// QueueBind indicates an expected call of QueueBind.
 func (mr *MockAMQPChannelMockRecorder) QueueBind(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueBind", reflect.TypeOf((*MockAMQPChannel)(nil).QueueBind), arg0, arg1, arg2, arg3, arg4)
 }
 
-// QueueDeclare mocks base method
+// QueueDeclare mocks base method.
 func (m *MockAMQPChannel) QueueDeclare(arg0 string, arg1, arg2, arg3, arg4 bool, arg5 amqp.Table) (amqp.Queue, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueueDeclare", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -150,7 +151,7 @@ func (m *MockAMQPChannel) QueueDeclare(arg0 string, arg1, arg2, arg3, arg4 bool,
 	return ret0, ret1
 }
 
-// QueueDeclare indicates an expected call of QueueDeclare
+// QueueDeclare indicates an expected call of QueueDeclare.
 func (mr *MockAMQPChannelMockRecorder) QueueDeclare(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueDeclare", reflect.TypeOf((*MockAMQPChannel)(nil).QueueDeclare), arg0, arg1, arg2, arg3, arg4, arg5)

--- a/dialer.go
+++ b/dialer.go
@@ -30,7 +30,6 @@ type AMQPConnection interface {
 type Connection struct {
 	amqpConn AMQPConnection
 	lostCh   chan struct{}
-	closeCh  chan struct{}
 }
 
 // AMQPConnection returns streadway's *amqp.Connection
@@ -41,10 +40,6 @@ func (c *Connection) AMQPConnection() *amqp.Connection {
 // NotifyLost notifies when current connection is lost and new once should be requested
 func (c *Connection) NotifyLost() chan struct{} {
 	return c.lostCh
-}
-
-func (c *Connection) NotifyClose() chan struct{} {
-	return c.closeCh
 }
 
 type config struct {
@@ -410,7 +405,7 @@ func (c *Dialer) connectedState(amqpConn AMQPConnection) error {
 
 	internalCloseCh := amqpConn.NotifyClose(make(chan *amqp.Error, 1))
 
-	conn := &Connection{amqpConn: amqpConn, lostCh: lostCh, closeCh: c.closedCh}
+	conn := &Connection{amqpConn: amqpConn, lostCh: lostCh}
 
 	c.logger.Printf("[DEBUG] connection ready")
 	c.notifyReady()

--- a/mock_amqpextra/mocks.go
+++ b/mock_amqpextra/mocks.go
@@ -5,35 +5,36 @@
 package mock_amqpextra
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	amqp "github.com/streadway/amqp"
-	reflect "reflect"
 )
 
-// MockAMQPConnection is a mock of AMQPConnection interface
+// MockAMQPConnection is a mock of AMQPConnection interface.
 type MockAMQPConnection struct {
 	ctrl     *gomock.Controller
 	recorder *MockAMQPConnectionMockRecorder
 }
 
-// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection
+// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection.
 type MockAMQPConnectionMockRecorder struct {
 	mock *MockAMQPConnection
 }
 
-// NewMockAMQPConnection creates a new mock instance
+// NewMockAMQPConnection creates a new mock instance.
 func NewMockAMQPConnection(ctrl *gomock.Controller) *MockAMQPConnection {
 	mock := &MockAMQPConnection{ctrl: ctrl}
 	mock.recorder = &MockAMQPConnectionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAMQPConnection) EXPECT() *MockAMQPConnectionMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockAMQPConnection) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -41,13 +42,13 @@ func (m *MockAMQPConnection) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockAMQPConnectionMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPConnection)(nil).Close))
 }
 
-// NotifyClose mocks base method
+// NotifyClose mocks base method.
 func (m *MockAMQPConnection) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyClose", arg0)
@@ -55,7 +56,7 @@ func (m *MockAMQPConnection) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error
 	return ret0
 }
 
-// NotifyClose indicates an expected call of NotifyClose
+// NotifyClose indicates an expected call of NotifyClose.
 func (mr *MockAMQPConnectionMockRecorder) NotifyClose(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyClose", reflect.TypeOf((*MockAMQPConnection)(nil).NotifyClose), arg0)

--- a/publisher.go
+++ b/publisher.go
@@ -44,7 +44,7 @@ func proxyPublisherConn(
 
 				select {
 				case publisherConnCh <- publisherConn:
-				case <-conn.NotifyClose():
+				case <-conn.NotifyLost():
 					continue
 				case <-publisherCloseCh:
 					return

--- a/publisher/mock_publisher/mocks.go
+++ b/publisher/mock_publisher/mocks.go
@@ -5,58 +5,59 @@
 package mock_publisher
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	amqp "github.com/streadway/amqp"
-	reflect "reflect"
 )
 
-// MockAMQPConnection is a mock of AMQPConnection interface
+// MockAMQPConnection is a mock of AMQPConnection interface.
 type MockAMQPConnection struct {
 	ctrl     *gomock.Controller
 	recorder *MockAMQPConnectionMockRecorder
 }
 
-// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection
+// MockAMQPConnectionMockRecorder is the mock recorder for MockAMQPConnection.
 type MockAMQPConnectionMockRecorder struct {
 	mock *MockAMQPConnection
 }
 
-// NewMockAMQPConnection creates a new mock instance
+// NewMockAMQPConnection creates a new mock instance.
 func NewMockAMQPConnection(ctrl *gomock.Controller) *MockAMQPConnection {
 	mock := &MockAMQPConnection{ctrl: ctrl}
 	mock.recorder = &MockAMQPConnectionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAMQPConnection) EXPECT() *MockAMQPConnectionMockRecorder {
 	return m.recorder
 }
 
-// MockAMQPChannel is a mock of AMQPChannel interface
+// MockAMQPChannel is a mock of AMQPChannel interface.
 type MockAMQPChannel struct {
 	ctrl     *gomock.Controller
 	recorder *MockAMQPChannelMockRecorder
 }
 
-// MockAMQPChannelMockRecorder is the mock recorder for MockAMQPChannel
+// MockAMQPChannelMockRecorder is the mock recorder for MockAMQPChannel.
 type MockAMQPChannelMockRecorder struct {
 	mock *MockAMQPChannel
 }
 
-// NewMockAMQPChannel creates a new mock instance
+// NewMockAMQPChannel creates a new mock instance.
 func NewMockAMQPChannel(ctrl *gomock.Controller) *MockAMQPChannel {
 	mock := &MockAMQPChannel{ctrl: ctrl}
 	mock.recorder = &MockAMQPChannelMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAMQPChannel) EXPECT() *MockAMQPChannelMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockAMQPChannel) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -64,13 +65,13 @@ func (m *MockAMQPChannel) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockAMQPChannelMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAMQPChannel)(nil).Close))
 }
 
-// Confirm mocks base method
+// Confirm mocks base method.
 func (m *MockAMQPChannel) Confirm(arg0 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Confirm", arg0)
@@ -78,13 +79,13 @@ func (m *MockAMQPChannel) Confirm(arg0 bool) error {
 	return ret0
 }
 
-// Confirm indicates an expected call of Confirm
+// Confirm indicates an expected call of Confirm.
 func (mr *MockAMQPChannelMockRecorder) Confirm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Confirm", reflect.TypeOf((*MockAMQPChannel)(nil).Confirm), arg0)
 }
 
-// NotifyClose mocks base method
+// NotifyClose mocks base method.
 func (m *MockAMQPChannel) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyClose", arg0)
@@ -92,13 +93,13 @@ func (m *MockAMQPChannel) NotifyClose(arg0 chan *amqp.Error) chan *amqp.Error {
 	return ret0
 }
 
-// NotifyClose indicates an expected call of NotifyClose
+// NotifyClose indicates an expected call of NotifyClose.
 func (mr *MockAMQPChannelMockRecorder) NotifyClose(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyClose", reflect.TypeOf((*MockAMQPChannel)(nil).NotifyClose), arg0)
 }
 
-// NotifyFlow mocks base method
+// NotifyFlow mocks base method.
 func (m *MockAMQPChannel) NotifyFlow(arg0 chan bool) chan bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyFlow", arg0)
@@ -106,13 +107,13 @@ func (m *MockAMQPChannel) NotifyFlow(arg0 chan bool) chan bool {
 	return ret0
 }
 
-// NotifyFlow indicates an expected call of NotifyFlow
+// NotifyFlow indicates an expected call of NotifyFlow.
 func (mr *MockAMQPChannelMockRecorder) NotifyFlow(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyFlow", reflect.TypeOf((*MockAMQPChannel)(nil).NotifyFlow), arg0)
 }
 
-// NotifyPublish mocks base method
+// NotifyPublish mocks base method.
 func (m *MockAMQPChannel) NotifyPublish(arg0 chan amqp.Confirmation) chan amqp.Confirmation {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyPublish", arg0)
@@ -120,13 +121,13 @@ func (m *MockAMQPChannel) NotifyPublish(arg0 chan amqp.Confirmation) chan amqp.C
 	return ret0
 }
 
-// NotifyPublish indicates an expected call of NotifyPublish
+// NotifyPublish indicates an expected call of NotifyPublish.
 func (mr *MockAMQPChannelMockRecorder) NotifyPublish(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPublish", reflect.TypeOf((*MockAMQPChannel)(nil).NotifyPublish), arg0)
 }
 
-// Publish mocks base method
+// Publish mocks base method.
 func (m *MockAMQPChannel) Publish(arg0, arg1 string, arg2, arg3 bool, arg4 amqp.Publishing) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Publish", arg0, arg1, arg2, arg3, arg4)
@@ -134,7 +135,7 @@ func (m *MockAMQPChannel) Publish(arg0, arg1 string, arg2, arg3 bool, arg4 amqp.
 	return ret0
 }
 
-// Publish indicates an expected call of Publish
+// Publish indicates an expected call of Publish.
 func (mr *MockAMQPChannelMockRecorder) Publish(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockAMQPChannel)(nil).Publish), arg0, arg1, arg2, arg3, arg4)


### PR DESCRIPTION
The current Connection API a bit to verbose. There are two ways you
should care about when it comes to permanent connection close.

First, handle close(connCh) properly.
Second conn.NotifyClose().

So I decide to remove the second option as redunded.