### PR TITLE
add WithTLS option

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -3,6 +3,7 @@ package amqpextra
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"sync"
 	"time"
@@ -161,6 +162,14 @@ func NewDialer(opts ...Option) (*Dialer, error) {
 func WithURL(urls ...string) Option {
 	return func(c *Dialer) {
 		c.amqpUrls = append(c.amqpUrls, urls...)
+	}
+}
+
+// WithTLS configure TLS.
+// tlsConfig TLS configuration to use
+func WithTLS(tlsConfig *tls.Config) Option {
+	return func(c *Dialer) {
+		c.amqpConfig.TLSClientConfig = tlsConfig
 	}
 }
 

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -1,6 +1,7 @@
 package amqpextra_test
 
 import (
+	"crypto/tls"
 	"errors"
 	"log"
 
@@ -97,6 +98,35 @@ func TestOptions(main *testing.T) {
 			amqpextra.WithURL("", "url"),
 		)
 		require.EqualError(t, err, "url(s) must be not empty")
+	})
+
+	main.Run("NoTLSConfig", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		dialer, err := amqpextra.NewDialer(
+			amqpextra.WithURL("url"),
+		)
+		require.Equal(t, nil, err)
+
+		dialer.Close()
+	})
+
+	main.Run("WithTLSConfig", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		dialer, err := amqpextra.NewDialer(
+			amqpextra.WithURL("url"),
+			amqpextra.WithTLS(&tls.Config{}),
+		)
+		assert.Equal(t, nil, err)
+
+		dialer.Close()
 	})
 }
 


### PR DESCRIPTION
At the moment, there is no way to set TLS configuration of the dialer. This PR provides a way to support this feature.