### PR TITLE
Consumer pool. In-process consumer autoscaling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Provides:
 * Auto reconnect.
 * Context aware.
 * Configured by WithXXX options.
-* Can process messages in parallel.
+* Consumer can process messages in parallel.
+* Consumers in-process auto-scaling and backpressure.
 * Adds message context.
 * Detects queue deletion and reconnect.
 * Notifies ready\unready\closed states.

--- a/consumerpool/pool.go
+++ b/consumerpool/pool.go
@@ -289,7 +289,6 @@ func DefaultDeciderFunc() func(queueSize, poolSize, preFetch int) int {
 		prevQueueSize = queueSize
 
 		if growCounter > 3 || queueSize > (poolSize*preFetch) {
-			growCounter = 0
 			return poolSize + 1
 		} else if emptyCounter > 20 {
 			emptyCounter -= 3

--- a/consumerpool/pool.go
+++ b/consumerpool/pool.go
@@ -1,0 +1,193 @@
+package consumerpool
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/makasim/amqpextra"
+	"github.com/makasim/amqpextra/consumer"
+)
+
+type Option func(p *Pool)
+
+func WithDecider(deciderFunc func(queueSize, poolSize, preFetch int) int) Option {
+	return func(p *Pool) {
+		p.deciderFunc = deciderFunc
+	}
+}
+
+func WithMinSize(size int) Option {
+	return func(p *Pool) {
+		p.minSize = size
+	}
+}
+
+func WithMaxSize(size int) Option {
+	return func(p *Pool) {
+		p.maxSize = size
+	}
+}
+
+type Pool struct {
+	dialerOptions   []amqpextra.Option
+	consumerOptions []consumer.Option
+
+	deciderFunc func(queueSize, poolSize, preFetch int) int
+
+	minSize int
+	maxSize int
+}
+
+func New(dialerOptions []amqpextra.Option, consumerOptions []consumer.Option, poolOptions []Option) (*Pool, error) {
+	p := &Pool{
+		dialerOptions:   dialerOptions,
+		consumerOptions: consumerOptions,
+
+		deciderFunc: DefaultDeciderFunc(),
+
+		minSize: 1,
+		maxSize: 10,
+	}
+
+	for _, opt := range poolOptions {
+		opt(p)
+	}
+
+	// todo: validate options
+
+	// amqpextra.WithURL("amqp://guest:guest@localhost:5672/test")
+	d, err := amqpextra.NewDialer(p.dialerOptions...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	conn, err := d.Connection(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	consumerPool := make([]*consumer.Consumer, 0)
+
+	var queueReady *consumer.Ready
+	for i := 0; i < p.minSize; i++ {
+		c, err := startConsumer(p.dialerOptions, p.consumerOptions)
+		if err != nil {
+			// todo: stop started consumers
+			return nil, err
+		}
+
+		if queueReady == nil {
+			for cState := range c.Notify(make(chan consumer.State, 1)) {
+				if cState.Ready != nil {
+					queueReady = cState.Ready
+					break
+				}
+			}
+		}
+
+		consumerPool = append(consumerPool, c)
+	}
+
+	if !queueReady.DeclareQueue {
+		return nil, fmt.Errorf("consumer pool can work with declared queue only")
+	}
+
+	go func() {
+		prefetch := queueReady.PrefetchCount
+
+		t := time.NewTicker(time.Second)
+		for {
+			<-t.C
+
+			q, err := ch.QueueDeclare(
+				queueReady.Queue,
+				queueReady.DeclareDurable,
+				queueReady.DeclareAutoDelete,
+				queueReady.DeclareExclusive,
+				queueReady.DeclareNoWait,
+				queueReady.DeclareArgs,
+			)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			poolSize := len(consumerPool)
+			queueSize := q.Messages
+
+			newPoolSize := p.deciderFunc(queueSize, poolSize, prefetch)
+
+			diff := newPoolSize - poolSize
+
+			if diff > 0 && poolSize < p.maxSize {
+				for i := 0; i < diff; i++ {
+					c, err := startConsumer(p.dialerOptions, p.consumerOptions)
+					if err != nil {
+						log.Fatal(err)
+					}
+
+					consumerPool = append(consumerPool, c)
+
+					if len(consumerPool) >= p.maxSize {
+						break
+					}
+				}
+			} else if diff < 0 && poolSize > p.minSize {
+				for i := 0; i < -diff; i++ {
+					consumerPool[len(consumerPool)-1].Close()
+					consumerPool = consumerPool[:len(consumerPool)-1]
+
+					if len(consumerPool) <= p.minSize {
+						break
+					}
+				}
+			}
+		}
+	}()
+
+	return p, nil
+}
+
+func (p *Pool) Close() {
+
+}
+
+func DefaultDeciderFunc() func(queueSize, poolSize, preFetch int) int {
+	var emptyCounter int
+
+	return func(queueSize, poolSize, preFetch int) int {
+		newPoolSize := poolSize
+
+		if queueSize < (poolSize*preFetch - int(float64(poolSize*preFetch)*0.2)) {
+			emptyCounter += 1
+		}
+
+		if queueSize > (poolSize*preFetch + int(float64(poolSize*preFetch)*0.2)) {
+			emptyCounter = 0
+			newPoolSize += 1
+		} else if emptyCounter > 5 {
+			emptyCounter = 0
+			newPoolSize -= 1
+		}
+
+		return newPoolSize
+	}
+}
+
+func startConsumer(dialerOptions []amqpextra.Option, consumerOptions []consumer.Option) (*consumer.Consumer, error) {
+	d, err := amqpextra.NewDialer(dialerOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("dialer: new: %s", err)
+	}
+
+	c, err := d.Consumer(consumerOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("consumer: new: %s", err)
+	}
+
+	return c, nil
+}

--- a/consumerpool/pool.go
+++ b/consumerpool/pool.go
@@ -274,8 +274,6 @@ func DefaultDeciderFunc() func(queueSize, poolSize, preFetch int) int {
 	var prevQueueSize int
 
 	return func(queueSize, poolSize, preFetch int) int {
-		newPoolSize := poolSize
-
 		if queueSize == 0 {
 			emptyCounter++
 		} else {
@@ -288,17 +286,17 @@ func DefaultDeciderFunc() func(queueSize, poolSize, preFetch int) int {
 			growCounter = 0
 		}
 
-		if growCounter > 3 || queueSize > (poolSize*preFetch) {
-			newPoolSize++
-			growCounter = 0
-		} else if emptyCounter > 20 {
-			emptyCounter -= 3
-			newPoolSize--
-		}
-
 		prevQueueSize = queueSize
 
-		return newPoolSize
+		if growCounter > 3 || queueSize > (poolSize*preFetch) {
+			growCounter = 0
+			return poolSize + 1
+		} else if emptyCounter > 20 {
+			emptyCounter -= 3
+			return poolSize - 1
+		}
+
+		return poolSize
 	}
 }
 

--- a/consumerpool/pool.go
+++ b/consumerpool/pool.go
@@ -88,6 +88,12 @@ func New(dialerOptions []amqpextra.Option, consumerOptions []consumer.Option, po
 		return nil, fmt.Errorf("prepare: %s", err)
 	}
 
+	if p.initCtx == nil {
+		var initCtxCancel context.CancelFunc
+		p.initCtx, initCtxCancel = context.WithTimeout(context.Background(), time.Second*5)
+		defer initCtxCancel()
+	}
+
 	decideDialer, err := amqpextra.NewDialer(p.dialerOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("dialer: new: %s", err)
@@ -380,11 +386,6 @@ func (p *Pool) prepare(options []Option) error {
 	}
 	if p.logger == nil {
 		p.logger = amqpextralogger.Discard
-	}
-	if p.initCtx == nil {
-		var initCtxCancel context.CancelFunc
-		p.initCtx, initCtxCancel = context.WithTimeout(context.Background(), time.Second*5)
-		defer initCtxCancel()
 	}
 
 	return nil

--- a/consumerpool/pool.go
+++ b/consumerpool/pool.go
@@ -248,7 +248,7 @@ func (p *Pool) connectedState(conn *amqpextra.Connection, cReady *amqpextraconsu
 						break
 					}
 				}
-				p.l.Printf(fmt.Sprintf("[INFO] increase pool size by %d, new len: %d", diff, len(p.cs)))
+				p.l.Printf(fmt.Sprintf("[INFO] increase pool by %d; queue: %d; new len: %d", diff, queueSize, len(p.cs)))
 			} else if diff < 0 && poolSize > p.minSize {
 				for i := 0; i < -diff; i++ {
 					// todo: wait for close
@@ -260,7 +260,7 @@ func (p *Pool) connectedState(conn *amqpextra.Connection, cReady *amqpextraconsu
 					}
 				}
 
-				p.l.Printf(fmt.Sprintf("[INFO] decrease pool size by %d, new len: %d", -diff, len(p.cs)))
+				p.l.Printf(fmt.Sprintf("[INFO] decrease pool by %d; new len: %d", -diff, len(p.cs)))
 			}
 		case <-conn.NotifyLost():
 			return
@@ -291,7 +291,7 @@ func DefaultDeciderFunc() func(queueSize, poolSize, preFetch int) int {
 		if growCounter > 3 || queueSize > (poolSize*preFetch) {
 			return poolSize + 1
 		} else if emptyCounter > 20 {
-			emptyCounter -= 3
+			emptyCounter -= 5
 			return poolSize - 1
 		}
 

--- a/e2e_test/consumerpool_test.go
+++ b/e2e_test/consumerpool_test.go
@@ -1,0 +1,65 @@
+package e2e_test
+
+import (
+	"context"
+	"log"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/makasim/amqpextra/consumerpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"go.uber.org/goleak"
+
+	"github.com/makasim/amqpextra"
+	"github.com/makasim/amqpextra/consumer"
+	"github.com/makasim/amqpextra/e2e_test/helper/rabbitmq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumePool(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	amqpConn, err := amqp.Dial("amqp://guest:guest@rabbitmq:5672/amqpextra")
+	require.NoError(t, err)
+	defer amqpConn.Close()
+
+	var consumedCounter int64
+
+	q := rabbitmq.Queue(amqpConn)
+	for i := 0; i < 2000; i++ {
+		rabbitmq.Publish(amqpConn, `Hello!`, q)
+	}
+
+	cp, err := consumerpool.New(
+		[]amqpextra.Option{
+			amqpextra.WithURL("amqp://guest:guest@rabbitmq:5672/amqpextra"),
+		},
+		[]consumer.Option{
+			consumer.WithQos(10, false),
+			consumer.WithWorker(consumer.NewParallelWorker(10)),
+			consumer.WithDeclareQueue(q, true, false, false, false, nil),
+			consumer.WithHandler(consumer.HandlerFunc(func(ctx context.Context, msg amqp.Delivery) interface{} {
+				atomic.AddInt64(&consumedCounter, 1)
+				time.Sleep(time.Millisecond * 100)
+				if err := msg.Ack(false); err != nil {
+					log.Fatal(err)
+				}
+
+				return nil
+			})),
+		},
+		[]consumerpool.Option{
+			consumerpool.WithMinSize(1),
+			consumerpool.WithMaxSize(10),
+		},
+	)
+	require.NoError(t, err)
+	defer cp.Close()
+
+	time.Sleep(time.Second * 6)
+	cp.Close()
+	<-cp.NotifyClosed()
+
+	require.Equal(t, int64(2000), atomic.LoadInt64(&consumedCounter))
+}

--- a/e2e_test/consumerpool_test.go
+++ b/e2e_test/consumerpool_test.go
@@ -42,8 +42,8 @@ func TestConsumePool(t *testing.T) {
 			consumer.WithHandler(consumer.HandlerFunc(func(ctx context.Context, msg amqp.Delivery) interface{} {
 				atomic.AddInt64(&consumedCounter, 1)
 				time.Sleep(time.Millisecond * 100)
-				if err := msg.Ack(false); err != nil {
-					log.Fatal(err)
+				if ackErr := msg.Ack(false); ackErr != nil {
+					log.Fatal(ackErr)
 				}
 
 				return nil


### PR DESCRIPTION
The consumer pool package would allow managing a pool of consumers as a unit. Each connection may run several consumers based on `WithConsumersPerConn` option.

The default decider scales consumers based on queue size. 
If there are messages a new consumer is started. 
If there is no message a consumer is stopped. 

`WithDecider` allows overwriting the default decider and adding backpressure capabilities. It could be a CPU backpressure or memory. 


Setup example:
```golang
cp, err := consumerpool.New(
  []amqpextra.Option{
    amqpextra.WithURL("amqp://guest:guest@localhost:5672/test"),
  },
  []consumer.Option{
    consumer.WithQos(prefetch, false),
    consumer.WithWorker(consumer.NewParallelWorker(prefetch)),
    consumer.WithDeclareQueue(`test-queue`, true, false, false, false, nil),
    consumer.WithHandler(consumer.HandlerFunc(func(ctx context.Context, msg amqp091.Delivery) interface{} {
      time.Sleep(time.Second)
      if err := msg.Ack(false); err != nil {
        log.Fatal(err)
      }
    
      return nil
    })),
  },
  []consumerpool.Option{
    consumerpool.WithMinSize(min),
    consumerpool.WithMaxSize(max),
  },
)

// ...

defer cp.Shutdown(context.Background())
```

CPU backpressure (do not scale if CPU util is higher 60%)
```golang
consumerpool.WithDecider(func(queueSize, poolSize, preFetch int) int {
  newPoolSize := defDecider(queueSize, poolSize, preFetch)
  
  cpuUtil := atomic.LoadInt64(&cpuUtilization)
  if cpuUtil > 60 {
    newPoolSize = poolSize - 1
  } else if cpuUtil > 50 {
    newPoolSize = poolSize
  }
  
  return newPoolSize
}),
```
